### PR TITLE
Release 3.2.0

### DIFF
--- a/Runtime/Plugins/Android/mainTemplate.gradle
+++ b/Runtime/Plugins/Android/mainTemplate.gradle
@@ -4,7 +4,7 @@ apply from: '../shared/keepUnitySymbols.gradle'
 
         dependencies {
             implementation fileTree(dir: 'libs', include: ['*.jar'])
-            implementation("com.aptoide:android-aptoide-billing:1.2.0")
+            implementation("com.aptoide:android-aptoide-billing:1.3.0")
             implementation("org.json:json:20210307")
             **DEPS**}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.aptoide.aptoideunitybillingsdk",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "displayName": "Aptoide Unity Billing SDK",
   "description": "UPM for Aptoide Billing SDK Integration",
   "unity": "2021.3",


### PR DESCRIPTION
# Release 3.2.0

[Release Notes](https://github.com/Aptoide/aptoide-unity-billing-sdk/releases/tag/release%2F3.2.0)